### PR TITLE
fix: graphページをrepositoryページに変更

### DIFF
--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -1,8 +1,0 @@
-export default function GraphPage() {
-  return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold mb-6">Graph</h1>
-      <p>グラフを表示するページです。</p>
-    </div>
-  )
-}

--- a/app/repository/page.tsx
+++ b/app/repository/page.tsx
@@ -1,0 +1,8 @@
+export default function RepositoryPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-6">Repository</h1>
+      <p>リポジトリを表示するページです。</p>
+    </div>
+  )
+}

--- a/types/navigation.ts
+++ b/types/navigation.ts
@@ -3,7 +3,7 @@ import { Home, BookOpen, BarChart, Briefcase, Mail, LucideIcon } from 'lucide-re
 export const routes = [
   { name: 'Hero', href: '/hero', label: 'ホーム', icon: Home },
   { name: 'NowTraining', href: '/nowtraining', label: '学習中', icon: BookOpen },
-  { name: 'Graph', href: '/graph', label: 'グラフ', icon: BarChart },
+  { name: 'Repository', href: '/repository', label: 'リポジトリ', icon: BarChart },
   { name: 'Career', href: '/career', label: 'キャリア', icon: Briefcase },
   { name: 'Contact', href: '/contact', label: 'お問い合わせ', icon: Mail }
 ] as const


### PR DESCRIPTION
## Summary
- graphページのルーティングをrepositoryに変更
- サイドバーのナビゲーション表示を更新
- 関連するコンポーネント名と表示テキストを修正

## Test plan
- [x] /repository にアクセスして正しく表示されることを確認
- [x] サイドバーから「リポジトリ」リンクが機能することを確認
- [x] lint, build, testが全て通ることを確認

Fixes #7

🤖 Generated with Claude Code