### PR TITLE
feat: repositoryページの実装

### DIFF
--- a/app/actions/getUserRepositories.ts
+++ b/app/actions/getUserRepositories.ts
@@ -1,0 +1,86 @@
+'use server';
+
+import { request } from 'graphql-request';
+import type { RepositoriesResponse, GetRepositoriesParams, Repository } from '@/types/repository';
+import { GITHUB_ENDPOINT, DEFAULT_GITHUB_USER, REPOSITORIES_PER_PAGE } from '@/constants/github';
+import { GET_USER_REPOSITORIES } from '@/queries/repositories';
+
+type GitHubGraphQLResponse = {
+  user: {
+    repositories: {
+      totalCount: number;
+      pageInfo: {
+        hasNextPage: boolean;
+        hasPreviousPage: boolean;
+        startCursor: string | null;
+        endCursor: string | null;
+      };
+      nodes: Repository[];
+    };
+  };
+};
+
+function getGitHubToken(): string {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('GITHUB_TOKEN environment variable is not set');
+  }
+  return token;
+}
+
+function createHeaders(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'NextJS-App'
+  } as const;
+}
+
+export async function getUserRepositories({
+  login = DEFAULT_GITHUB_USER,
+  first = REPOSITORIES_PER_PAGE,
+  after = null
+}: GetRepositoriesParams = {}): Promise<RepositoriesResponse> {
+  try {
+    const token = getGitHubToken();
+    const headers = createHeaders(token);
+
+    console.log('Fetching repositories:', {
+      login,
+      first,
+      after,
+      hasToken: !!token
+    });
+
+    const response = await request<GitHubGraphQLResponse>(
+      GITHUB_ENDPOINT,
+      GET_USER_REPOSITORIES,
+      { login, first, after },
+      headers
+    );
+
+    const { repositories } = response.user;
+
+    return {
+      repositories: repositories.nodes,
+      pageInfo: repositories.pageInfo,
+      totalCount: repositories.totalCount
+    };
+  } catch (error) {
+    console.error('Failed to fetch repositories:', error);
+    
+    if (error instanceof Error && error.message.includes('403')) {
+      console.error('GitHub Token may need these scopes: read:user, repo');
+    }
+    
+    return {
+      repositories: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: null
+      },
+      totalCount: 0
+    };
+  }
+}

--- a/app/repository/page.tsx
+++ b/app/repository/page.tsx
@@ -1,8 +1,13 @@
-export default function RepositoryPage() {
+import { getUserRepositories } from '@/app/actions/getUserRepositories';
+import RepositoryPageClient from '@/components/repository/RepositoryPageClient';
+
+export default async function RepositoryPage() {
+  const initialData = await getUserRepositories();
+
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-6">Repository</h1>
-      <p>リポジトリを表示するページです。</p>
+      <RepositoryPageClient initialData={initialData} />
     </div>
-  )
+  );
 }

--- a/app/repository/page.tsx
+++ b/app/repository/page.tsx
@@ -1,5 +1,6 @@
 import { getUserRepositories } from '@/app/actions/getUserRepositories';
 import RepositoryPageClient from '@/components/repository/RepositoryPageClient';
+import RepositoryLegend from '@/components/repository/RepositoryLegend';
 
 export default async function RepositoryPage() {
   const initialData = await getUserRepositories();
@@ -7,6 +8,7 @@ export default async function RepositoryPage() {
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-6">Repository</h1>
+      <RepositoryLegend />
       <RepositoryPageClient initialData={initialData} />
     </div>
   );

--- a/atoms/repositoryAtoms.ts
+++ b/atoms/repositoryAtoms.ts
@@ -1,0 +1,12 @@
+import { atom } from 'jotai';
+import type { Repository, PageInfo } from '@/types/repository';
+
+export const repositoriesAtom = atom<Repository[]>([]);
+
+export const pageInfoAtom = atom<PageInfo | null>(null);
+
+export const currentPageAtom = atom<number>(1);
+
+export const totalCountAtom = atom<number>(0);
+
+export const isLoadingAtom = atom<boolean>(false);

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -11,7 +11,8 @@ export function MainContent({ children }: MainContentProps) {
   const [isOpen] = useAtom(sidebarOpenAtom)
 
   return (
-    <main className={isOpen ? 'ml-64' : 'ml-16'}>
+    // <main className={isOpen ? 'ml-64' : 'ml-16'}>
+    <main className="ml-16">
       {children}
     </main>
   )

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -1,14 +1,9 @@
-'use client'
-
-import { useAtom } from 'jotai'
-import { sidebarOpenAtom } from '@/atoms/sidebarAtoms'
 
 interface MainContentProps {
   children: React.ReactNode
 }
 
 export function MainContent({ children }: MainContentProps) {
-  const [isOpen] = useAtom(sidebarOpenAtom)
 
   return (
     // <main className={isOpen ? 'ml-64' : 'ml-16'}>

--- a/components/repository/RepositoryCard.tsx
+++ b/components/repository/RepositoryCard.tsx
@@ -11,8 +11,15 @@ type RepositoryCardProps = {
 export default function RepositoryCard({ repository }: RepositoryCardProps) {
   const languageIcon = getLanguageIcon(repository.primaryLanguage?.name || null);
   
+  const handleCardClick = () => {
+    window.open(repository.url, '_blank', 'noopener,noreferrer');
+  };
+  
   return (
-    <Card className="h-full hover:shadow-lg transition-shadow duration-200">
+    <Card 
+      className="h-full hover:shadow-lg transition-shadow duration-200 cursor-pointer" 
+      onClick={handleCardClick}
+    >
       <CardHeader className="pb-3">
         <div className="flex items-center gap-3">
           {languageIcon && (

--- a/components/repository/RepositoryCard.tsx
+++ b/components/repository/RepositoryCard.tsx
@@ -1,0 +1,80 @@
+import Image from 'next/image';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { Repository } from '@/types/repository';
+import { getLanguageIcon } from '@/lib/utils/language';
+
+type RepositoryCardProps = {
+  repository: Repository;
+};
+
+export default function RepositoryCard({ repository }: RepositoryCardProps) {
+  const languageIcon = getLanguageIcon(repository.primaryLanguage?.name || null);
+  
+  return (
+    <Card className="h-full hover:shadow-lg transition-shadow duration-200">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          {languageIcon && (
+            <Image 
+              src={languageIcon} 
+              alt={repository.primaryLanguage?.name || 'Language'} 
+              width={32}
+              height={32}
+              className="w-8 h-8"
+            />
+          )}
+          <div className="flex-1 min-w-0">
+            <CardTitle className="text-lg font-semibold truncate">
+              {repository.name}
+            </CardTitle>
+            {repository.primaryLanguage && (
+              <Badge variant="secondary" className="mt-1 text-xs">
+                {repository.primaryLanguage.name}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      
+      <CardContent className="pt-0">
+        <p className="text-sm text-muted-foreground mb-4 line-clamp-2 min-h-[2.5rem]">
+          {repository.description || 'No description available'}
+        </p>
+        
+        <div className="flex items-center gap-4 text-sm">
+          <div className="flex items-center gap-1">
+            <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
+            <span className="text-muted-foreground">
+              {repository.defaultBranchRef?.target?.history?.totalCount || 0}
+            </span>
+          </div>
+          
+          <div className="flex items-center gap-1">
+            <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+            <span className="text-muted-foreground">
+              {repository.pullRequests.totalCount}
+            </span>
+          </div>
+          
+          <div className="flex items-center gap-1">
+            <div className="w-3 h-3 bg-red-500 rounded-full"></div>
+            <span className="text-muted-foreground">
+              {repository.issues.totalCount}
+            </span>
+          </div>
+        </div>
+        
+        <div className="flex items-center justify-between mt-4 text-xs text-muted-foreground">
+          <span>
+            Updated: {new Date(repository.updatedAt).toLocaleDateString()}
+          </span>
+          <div className="flex items-center gap-2">
+            <span>⭐ {repository.stargazerCount}</span>
+            <span>🍴 {repository.forkCount}</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/repository/RepositoryCardSkeleton.tsx
+++ b/components/repository/RepositoryCardSkeleton.tsx
@@ -1,0 +1,48 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function RepositoryCardSkeleton() {
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-8 h-8 rounded-md" />
+          <div className="flex-1 min-w-0">
+            <Skeleton className="h-6 w-3/4 mb-2" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+      </CardHeader>
+      
+      <CardContent className="pt-0">
+        <div className="space-y-2 mb-4">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+        
+        <div className="flex items-center gap-4 mb-4">
+          <div className="flex items-center gap-1">
+            <Skeleton className="w-3 h-3 rounded-full" />
+            <Skeleton className="h-4 w-6" />
+          </div>
+          <div className="flex items-center gap-1">
+            <Skeleton className="w-3 h-3 rounded-full" />
+            <Skeleton className="h-4 w-6" />
+          </div>
+          <div className="flex items-center gap-1">
+            <Skeleton className="w-3 h-3 rounded-full" />
+            <Skeleton className="h-4 w-6" />
+          </div>
+        </div>
+        
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-3 w-24" />
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-3 w-8" />
+            <Skeleton className="h-3 w-8" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/repository/RepositoryLegend.tsx
+++ b/components/repository/RepositoryLegend.tsx
@@ -1,0 +1,20 @@
+export default function RepositoryLegend() {
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 mb-6 p-4 bg-muted/30 rounded-lg">
+      <div className="flex items-center gap-2 text-sm">
+        <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
+        <span className="text-muted-foreground">コミット数</span>
+      </div>
+      
+      <div className="flex items-center gap-2 text-sm">
+        <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+        <span className="text-muted-foreground">PullRequest数</span>
+      </div>
+      
+      <div className="flex items-center gap-2 text-sm">
+        <div className="w-3 h-3 bg-red-500 rounded-full"></div>
+        <span className="text-muted-foreground">Issue数</span>
+      </div>
+    </div>
+  );
+}

--- a/components/repository/RepositoryPageClient.tsx
+++ b/components/repository/RepositoryPageClient.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { useAtom } from 'jotai';
+import { getUserRepositories } from '@/app/actions/getUserRepositories';
+import RepositoryCard from '@/components/repository/RepositoryCard';
+import RepositoryCardSkeleton from '@/components/repository/RepositoryCardSkeleton';
+import RepositoryPagination from '@/components/repository/RepositoryPagination';
+import { 
+  repositoriesAtom, 
+  pageInfoAtom, 
+  currentPageAtom, 
+  totalCountAtom, 
+  isLoadingAtom 
+} from '@/atoms/repositoryAtoms';
+import type { RepositoriesResponse } from '@/types/repository';
+
+type RepositoryPageClientProps = {
+  initialData: RepositoriesResponse;
+};
+
+export default function RepositoryPageClient({ initialData }: RepositoryPageClientProps) {
+  const [repositories, setRepositories] = useAtom(repositoriesAtom);
+  const [, setPageInfo] = useAtom(pageInfoAtom);
+  const [currentPage, setCurrentPage] = useAtom(currentPageAtom);
+  const [, setTotalCount] = useAtom(totalCountAtom);
+  const [isLoading, setIsLoading] = useAtom(isLoadingAtom);
+  
+  const [cursors, setCursors] = useState<string[]>([]);
+  const [initialized, setInitialized] = useState(false);
+
+  // 初期データを設定
+  if (!initialized) {
+    setInitialized(true);
+    setRepositories(initialData.repositories);
+    setPageInfo(initialData.pageInfo);
+    setTotalCount(initialData.totalCount);
+    setCurrentPage(1);
+    
+    if (initialData.pageInfo.endCursor) {
+      setCursors([initialData.pageInfo.endCursor]);
+    }
+  }
+
+  const fetchRepositories = async (page: number) => {
+    setIsLoading(true);
+    try {
+      const after = page > 1 ? cursors[page - 2] : null;
+      const data = await getUserRepositories({ after });
+      
+      setRepositories(data.repositories);
+      setPageInfo(data.pageInfo);
+      setTotalCount(data.totalCount);
+      
+      if (data.pageInfo.endCursor && !cursors[page - 1]) {
+        setCursors(prev => {
+          const newCursors = [...prev];
+          newCursors[page - 1] = data.pageInfo.endCursor!;
+          return newCursors;
+        });
+      }
+    } catch (error) {
+      console.error('Failed to fetch repositories:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    if (page !== currentPage) {
+      setCurrentPage(page);
+      fetchRepositories(page);
+    }
+  };
+
+  if (!initialized) {
+    return (
+      <>
+        <div className="mb-6">
+          <div className="flex justify-center">
+            <div className="h-10 w-64 bg-muted rounded-md animate-pulse" />
+          </div>
+        </div>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+          {Array.from({ length: 10 }, (_, index) => (
+            <RepositoryCardSkeleton key={index} />
+          ))}
+        </div>
+        
+        <div className="mt-8">
+          <div className="flex justify-center">
+            <div className="h-10 w-64 bg-muted rounded-md animate-pulse" />
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-6">
+        <RepositoryPagination onPageChange={handlePageChange} />
+      </div>
+      
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+          {Array.from({ length: 10 }, (_, index) => (
+            <RepositoryCardSkeleton key={index} />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
+          {repositories.map((repository) => (
+            <RepositoryCard key={repository.id} repository={repository} />
+          ))}
+        </div>
+      )}
+      
+      {!isLoading && (
+        <div className="mt-8">
+          <RepositoryPagination onPageChange={handlePageChange} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/repository/RepositoryPagination.tsx
+++ b/components/repository/RepositoryPagination.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { currentPageAtom, totalCountAtom, pageInfoAtom } from '@/atoms/repositoryAtoms';
+import { REPOSITORIES_PER_PAGE } from '@/constants/github';
+
+type RepositoryPaginationProps = {
+  onPageChange: (page: number) => void;
+};
+
+export default function RepositoryPagination({ onPageChange }: RepositoryPaginationProps) {
+  const [currentPage] = useAtom(currentPageAtom);
+  const [totalCount] = useAtom(totalCountAtom);
+  const [pageInfo] = useAtom(pageInfoAtom);
+  
+  const totalPages = Math.ceil(totalCount / REPOSITORIES_PER_PAGE);
+  const hasNextPage = pageInfo?.hasNextPage ?? false;
+  const hasPreviousPage = currentPage > 1;
+  
+  if (totalPages <= 1) return null;
+  
+  const handlePreviousPage = () => {
+    if (hasPreviousPage) {
+      onPageChange(currentPage - 1);
+    }
+  };
+  
+  const handleNextPage = () => {
+    if (hasNextPage) {
+      onPageChange(currentPage + 1);
+    }
+  };
+  
+  return (
+    <div className="flex items-center justify-center gap-6">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handlePreviousPage}
+        disabled={!hasPreviousPage}
+        className="flex items-center gap-2"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Previous
+      </Button>
+      
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <span>Page {currentPage} of {totalPages}</span>
+        <span>•</span>
+        <span>{totalCount} repositories</span>
+      </div>
+      
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleNextPage}
+        disabled={!hasNextPage}
+        className="flex items-center gap-2"
+      >
+        Next
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/constants/github.ts
+++ b/constants/github.ts
@@ -1,0 +1,3 @@
+export const GITHUB_ENDPOINT = 'https://api.github.com/graphql';
+export const DEFAULT_GITHUB_USER = 'gs223gs';
+export const REPOSITORIES_PER_PAGE = 10;

--- a/constants/github.ts
+++ b/constants/github.ts
@@ -1,3 +1,4 @@
 export const GITHUB_ENDPOINT = 'https://api.github.com/graphql';
 export const DEFAULT_GITHUB_USER = 'gs223gs';
 export const REPOSITORIES_PER_PAGE = 10;
+export const GITHUB_BASE_URL = 'https://github.com';

--- a/lib/utils/language.ts
+++ b/lib/utils/language.ts
@@ -1,0 +1,51 @@
+export function getLanguageIcon(language: string | null): string {
+  if (!language) return '';
+  
+  const languageMap: Record<string, string> = {
+    'JavaScript': 'js',
+    'TypeScript': 'ts',
+    'Python': 'py',
+    'Java': 'java',
+    'C++': 'cpp',
+    'C': 'c',
+    'C#': 'cs',
+    'Go': 'go',
+    'Rust': 'rust',
+    'PHP': 'php',
+    'Ruby': 'ruby',
+    'Swift': 'swift',
+    'Kotlin': 'kotlin',
+    'Dart': 'dart',
+    'HTML': 'html',
+    'CSS': 'css',
+    'SCSS': 'scss',
+    'Vue': 'vue',
+    'React': 'react',
+    'Angular': 'angular',
+    'Node.js': 'nodejs',
+    'Express': 'express',
+    'Next.js': 'nextjs',
+    'Nuxt.js': 'nuxtjs',
+    'Svelte': 'svelte',
+    'Flutter': 'flutter',
+    'Docker': 'docker',
+    'Kubernetes': 'kubernetes',
+    'MySQL': 'mysql',
+    'PostgreSQL': 'postgres',
+    'MongoDB': 'mongodb',
+    'Redis': 'redis',
+    'Git': 'git',
+    'GitHub': 'github',
+    'GitLab': 'gitlab',
+    'Vim': 'vim',
+    'Shell': 'bash',
+    'PowerShell': 'powershell',
+    'Markdown': 'md',
+    'JSON': 'json',
+    'XML': 'xml',
+    'YAML': 'yaml'
+  };
+  
+  const iconName = languageMap[language] || language.toLowerCase();
+  return `https://skillicons.dev/icons?i=${iconName}`;
+}

--- a/queries/repositories.ts
+++ b/queries/repositories.ts
@@ -1,0 +1,54 @@
+import { gql } from 'graphql-request';
+
+export const GET_USER_REPOSITORIES = gql`
+  query GetUserRepositories($login: String!, $first: Int!, $after: String) {
+    user(login: $login) {
+      repositories(
+        first: $first
+        after: $after
+        orderBy: { field: UPDATED_AT, direction: DESC }
+        ownerAffiliations: OWNER
+        privacy: PUBLIC
+      ) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        nodes {
+          id
+          name
+          description
+          url
+          updatedAt
+          stargazerCount
+          forkCount
+          isPrivate
+          isFork
+          isArchived
+          primaryLanguage {
+            name
+            color
+          }
+          defaultBranchRef {
+            target {
+              ... on Commit {
+                history {
+                  totalCount
+                }
+              }
+            }
+          }
+          pullRequests {
+            totalCount
+          }
+          issues {
+            totalCount
+          }
+        }
+      }
+    }
+  }
+`;

--- a/todos/docs/server actions実装について.md
+++ b/todos/docs/server actions実装について.md
@@ -1,0 +1,236 @@
+# Server Actions実装について
+
+## 概要
+GitHub APIを使用してリポジトリ情報を取得するServer Actionの実装方法
+
+## ファイル構成
+
+```
+app/actions/
+├── getUserRepositories.ts    # リポジトリ取得用Server Action
+├── githubApiFetch.ts        # コントリビューション取得用Server Action
+constants/
+├── github.ts               # GitHub関連の定数
+queries/
+├── repositories.ts         # GraphQLクエリ
+types/
+├── repository.ts          # リポジトリ関連の型定義
+```
+
+## 実装手順
+
+### 1. 定数の定義
+```typescript
+// constants/github.ts
+export const GITHUB_ENDPOINT = 'https://api.github.com/graphql';
+export const DEFAULT_GITHUB_USER = 'gs223gs';
+export const REPOSITORIES_PER_PAGE = 10;
+```
+
+### 2. 型定義
+```typescript
+// types/repository.ts
+export type Repository = {
+  id: string;
+  name: string;
+  description: string | null;
+  url: string;
+  updatedAt: string;
+  // その他のフィールド...
+};
+
+export type PageInfo = {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+};
+
+export type RepositoriesResponse = {
+  repositories: Repository[];
+  pageInfo: PageInfo;
+  totalCount: number;
+};
+```
+
+### 3. GraphQLクエリ
+```typescript
+// queries/repositories.ts
+import { gql } from 'graphql-request';
+
+export const GET_USER_REPOSITORIES = gql`
+  query GetUserRepositories($login: String!, $first: Int!, $after: String) {
+    user(login: $login) {
+      repositories(
+        first: $first
+        after: $after
+        orderBy: { field: UPDATED_AT, direction: DESC }
+        ownerAffiliations: OWNER
+        privacy: PUBLIC
+      ) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          name
+          description
+          url
+          updatedAt
+          # その他のフィールド...
+        }
+      }
+    }
+  }
+`;
+```
+
+### 4. Server Action実装
+```typescript
+// app/actions/getUserRepositories.ts
+'use server';
+
+import { request } from 'graphql-request';
+import type { RepositoriesResponse, GetRepositoriesParams } from '@/types/repository';
+import { GITHUB_ENDPOINT, DEFAULT_GITHUB_USER, REPOSITORIES_PER_PAGE } from '@/constants/github';
+import { GET_USER_REPOSITORIES } from '@/queries/repositories';
+
+export async function getUserRepositories({
+  login = DEFAULT_GITHUB_USER,
+  first = REPOSITORIES_PER_PAGE,
+  after = null
+}: GetRepositoriesParams = {}): Promise<RepositoriesResponse> {
+  // 実装...
+}
+```
+
+## 設計原則
+
+### 1. 責任の分離
+- **定数**: `constants/` ディレクトリに分離
+- **型定義**: `types/` ディレクトリに分離
+- **クエリ**: `queries/` ディレクトリに分離
+- **Server Action**: `app/actions/` ディレクトリに配置
+
+### 2. エラーハンドリング
+```typescript
+try {
+  const response = await request(/* ... */);
+  return transformResponse(response);
+} catch (error) {
+  console.error('Failed to fetch repositories:', error);
+  
+  // 403エラーの場合、具体的なヒントを提供
+  if (error instanceof Error && error.message.includes('403')) {
+    console.error('GitHub Token may need these scopes: read:user, repo');
+  }
+  
+  // エラー時はデフォルト値を返す
+  return {
+    repositories: [],
+    pageInfo: { hasNextPage: false, /* ... */ },
+    totalCount: 0
+  };
+}
+```
+
+### 3. セキュリティ
+- 環境変数からGitHubトークンを取得
+- トークンの存在確認
+- 適切なヘッダー設定
+
+```typescript
+function getGitHubToken(): string {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('GITHUB_TOKEN environment variable is not set');
+  }
+  return token;
+}
+
+function createHeaders(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'NextJS-App'
+  } as const;
+}
+```
+
+## 環境変数設定
+
+```bash
+# .env.local
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+必要なスコープ:
+- `read:user`: ユーザー情報の読み取り
+- `repo`: リポジトリ情報の読み取り（プライベートリポジトリも含む場合）
+
+## 使用方法
+
+### Server Component
+```tsx
+import { getUserRepositories } from '@/app/actions/getUserRepositories';
+
+export default async function RepositoryPage() {
+  const data = await getUserRepositories();
+  
+  return (
+    <div>
+      {data.repositories.map(repo => (
+        <div key={repo.id}>{repo.name}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+### Client Component
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getUserRepositories } from '@/app/actions/getUserRepositories';
+
+export default function RepositoryPage() {
+  const [repositories, setRepositories] = useState([]);
+  
+  useEffect(() => {
+    getUserRepositories().then(data => {
+      setRepositories(data.repositories);
+    });
+  }, []);
+  
+  return (
+    // JSX...
+  );
+}
+```
+
+## テスト
+
+```typescript
+// app/actions/getUserRepositories.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { getUserRepositories } from './getUserRepositories';
+
+describe('getUserRepositories', () => {
+  it('should fetch repositories successfully', async () => {
+    // テスト実装...
+  });
+  
+  it('should handle API errors gracefully', async () => {
+    // エラーケースのテスト...
+  });
+});
+```
+
+## 注意点
+
+1. **APIレート制限**: GitHub APIの制限（5000回/時間）に注意
+2. **型安全性**: TypeScriptの型チェックを活用
+3. **エラーハンドリング**: 適切なフォールバック処理
+4. **パフォーマンス**: ページネーションを活用した効率的なデータ取得

--- a/todos/docs/ページネーション手順.md
+++ b/todos/docs/ページネーション手順.md
@@ -1,0 +1,147 @@
+# ページネーション手順
+
+## 概要
+GitHub APIを使用してリポジトリ情報を取得する際のページネーション実装手順
+
+## 実装手順
+
+### 1. Server Actionの呼び出し
+```tsx
+import { getUserRepositories } from '@/app/actions/getUserRepositories';
+
+// 初回データ取得
+const initialData = await getUserRepositories();
+
+// 次のページを取得
+const nextPageData = await getUserRepositories({
+  after: currentPageInfo.endCursor
+});
+```
+
+### 2. 状態管理
+```tsx
+const [repositories, setRepositories] = useState<Repository[]>([]);
+const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
+const [loading, setLoading] = useState(false);
+```
+
+### 3. データの追加処理
+```tsx
+const loadMoreRepositories = async () => {
+  if (!pageInfo?.hasNextPage) return;
+  
+  setLoading(true);
+  try {
+    const newData = await getUserRepositories({
+      after: pageInfo.endCursor
+    });
+    
+    setRepositories(prev => [...prev, ...newData.repositories]);
+    setPageInfo(newData.pageInfo);
+  } catch (error) {
+    console.error('Failed to load more repositories:', error);
+  } finally {
+    setLoading(false);
+  }
+};
+```
+
+### 4. UIでの表示
+```tsx
+return (
+  <div>
+    {repositories.map(repo => (
+      <RepositoryCard key={repo.id} repository={repo} />
+    ))}
+    
+    {pageInfo?.hasNextPage && (
+      <Button onClick={loadMoreRepositories} disabled={loading}>
+        {loading ? 'Loading...' : 'Load More'}
+      </Button>
+    )}
+  </div>
+);
+```
+
+## パラメータ
+
+- `first`: 取得する件数（デフォルト: 10）
+- `after`: 開始位置のカーソル（次のページ取得時に使用）
+- `login`: GitHubユーザー名（デフォルト: 'gs223gs'）
+
+## 注意点
+
+1. **カーソルベースページネーション**: GitHub APIはカーソルベースのため、`endCursor`を使用して次のページを取得
+2. **重複チェック**: 同じリポジトリが重複して追加されないよう、必要に応じてチェック
+3. **エラーハンドリング**: ネットワークエラーやAPI制限エラーの適切な処理
+4. **ローディング状態**: ユーザーエクスペリエンスのためのローディング表示
+
+## 実装例
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getUserRepositories } from '@/app/actions/getUserRepositories';
+import type { Repository, PageInfo } from '@/types/repository';
+
+export default function RepositoryPage() {
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    const fetchInitialData = async () => {
+      try {
+        const data = await getUserRepositories();
+        setRepositories(data.repositories);
+        setPageInfo(data.pageInfo);
+      } catch (error) {
+        console.error('Failed to fetch repositories:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchInitialData();
+  }, []);
+
+  const loadMore = async () => {
+    if (!pageInfo?.hasNextPage || loadingMore) return;
+    
+    setLoadingMore(true);
+    try {
+      const data = await getUserRepositories({
+        after: pageInfo.endCursor
+      });
+      
+      setRepositories(prev => [...prev, ...data.repositories]);
+      setPageInfo(data.pageInfo);
+    } catch (error) {
+      console.error('Failed to load more repositories:', error);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      {repositories.map(repo => (
+        <div key={repo.id}>
+          <h3>{repo.name}</h3>
+          <p>{repo.description}</p>
+        </div>
+      ))}
+      
+      {pageInfo?.hasNextPage && (
+        <button onClick={loadMore} disabled={loadingMore}>
+          {loadingMore ? 'Loading...' : 'Load More'}
+        </button>
+      )}
+    </div>
+  );
+}
+```

--- a/types/repository.ts
+++ b/types/repository.ts
@@ -1,0 +1,48 @@
+export type Repository = {
+  id: string;
+  name: string;
+  description: string | null;
+  url: string;
+  updatedAt: string;
+  primaryLanguage: {
+    name: string;
+    color: string;
+  } | null;
+  defaultBranchRef: {
+    target: {
+      history: {
+        totalCount: number;
+      };
+    };
+  } | null;
+  pullRequests: {
+    totalCount: number;
+  };
+  issues: {
+    totalCount: number;
+  };
+  stargazerCount: number;
+  forkCount: number;
+  isPrivate: boolean;
+  isFork: boolean;
+  isArchived: boolean;
+}
+
+export type PageInfo = {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+}
+
+export type RepositoriesResponse = {
+  repositories: Repository[];
+  pageInfo: PageInfo;
+  totalCount: number;
+}
+
+export type GetRepositoriesParams = {
+  login?: string;
+  first?: number;
+  after?: string | null;
+}


### PR DESCRIPTION
## Summary
- GitHub APIを使用してリポジトリ情報を取得・表示
- ページネーション機能（カーソルベース）
- リポジトリカードのクリック機能
- スケルトンローディング
- アイコン説明の追加

## 主な機能
- 1ページあたり10件のリポジトリ表示
- リポジトリ名、説明、言語、コミット数、PR数、Issue数を表示
- 言語アイコンはskillicons.devから取得
- カードクリックでGitHubリポジトリに遷移
- レスポンシブデザイン対応

## 技術的な特徴
- Server/Client分離でパフォーマンス最適化
- Jotaiによる状態管理
- カーソルベースページネーション
- スケルトンローディングによるUX向上

## Test plan
- [x] リポジトリ一覧が正しく表示される
- [x] ページネーションが動作する
- [x] カードクリックでリポジトリに遷移する
- [x] スケルトンローディングが表示される
- [x] アイコン説明が表示される
- [x] モバイルでレスポンシブ対応

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a paginated GitHub repository list with server-side data fetching and client-side pagination controls.
  * Added repository cards displaying key details such as language, description, commit, pull request, and issue counts, with responsive skeleton loading states.
  * Included a visual legend for repository metrics and intuitive pagination navigation.
  * Implemented state management for repositories, pagination, and loading indicators.

* **Documentation**
  * Added detailed guides explaining server action implementation and cursor-based pagination for GitHub repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->